### PR TITLE
fix a bug on safari that popstate event is fired during page load

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = (function () {
 
   var onUrlChange = function (type) {
     return function (event) {
-      if (location.href === prevUrl) {
+      if (!event.state || location.href === prevUrl) {
         return
       }
 


### PR DESCRIPTION
on safari cerebral-router will trigger twice during page load.
